### PR TITLE
Fix parsing issue when using Medusa 0.1.3

### DIFF
--- a/fuzz_utils/fuzzers/Medusa.py
+++ b/fuzz_utils/fuzzers/Medusa.py
@@ -76,8 +76,12 @@ class Medusa:
         has_delay = time_delay > 0 or block_delay > 0
 
         # TODO check how Medusa handles empty calls
-
-        function_name = call_dict["call"]["dataAbiValues"]["methodName"]
+        if "methodName" in call_dict["call"]["dataAbiValues"]:
+            function_name = call_dict["call"]["dataAbiValues"]["methodName"]
+        elif "methodSignature" in call_dict["call"]["dataAbiValues"]:
+            function_name = call_dict["call"]["dataAbiValues"]["methodSignature"].split("(")[0]
+        else:
+            handle_exit("There was an issue parsing the Medusa call sequences. This indicates a breaking change in the call sequence format, please open an issue at https://github.com/crytic/fuzz-utils/issues")
         function_parameters = call_dict["call"]["dataAbiValues"]["inputValues"]
         if len(function_parameters) == 0:
             function_parameters = ""

--- a/fuzz_utils/fuzzers/Medusa.py
+++ b/fuzz_utils/fuzzers/Medusa.py
@@ -74,6 +74,7 @@ class Medusa:
         time_delay = int(call_dict["blockTimestampDelay"])
         block_delay = int(call_dict["blockNumberDelay"])
         has_delay = time_delay > 0 or block_delay > 0
+        function_name: str = ""
 
         # TODO check how Medusa handles empty calls
         if "methodName" in call_dict["call"]["dataAbiValues"]:

--- a/fuzz_utils/fuzzers/Medusa.py
+++ b/fuzz_utils/fuzzers/Medusa.py
@@ -81,7 +81,9 @@ class Medusa:
         elif "methodSignature" in call_dict["call"]["dataAbiValues"]:
             function_name = call_dict["call"]["dataAbiValues"]["methodSignature"].split("(")[0]
         else:
-            handle_exit("There was an issue parsing the Medusa call sequences. This indicates a breaking change in the call sequence format, please open an issue at https://github.com/crytic/fuzz-utils/issues")
+            handle_exit(
+                "There was an issue parsing the Medusa call sequences. This indicates a breaking change in the call sequence format, please open an issue at https://github.com/crytic/fuzz-utils/issues"
+            )
         function_parameters = call_dict["call"]["dataAbiValues"]["inputValues"]
         if len(function_parameters) == 0:
             function_parameters = ""


### PR DESCRIPTION
Fixes call sequence parsing of sequences generated by Medusa 0.1.3, keeps backwards support for <0.1.3. Related to https://github.com/crytic/fuzz-utils/issues/28