### PR TITLE
Add `template` modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ The `template` command is used to generate a fuzzing harness. The harness can in
 - `-c`/`--contracts` `target_contracts: list`: The name of the target contract.
 - `-o`/`--output-dir` `output_directory: str`: Output directory name. By default it is `fuzzing`
 - `--config`: Path to the `fuzz-utils` config JSON file
+- `--mode`: The strategy to use when generating the harnesses. Valid options: `simple`, `prank`, `actor`
+
+**Generation modes**
+The tool support three harness generation strategies:
+- `simple` - The fuzzing harness will be generated with all of the state-changing functions from the target contracts. All function calls are performed directly, with the harness contract as the `msg.sender`.
+- `prank` - Similar to `simple` mode, with the difference that function calls are made from different users by using `hevm.prank()`. The users can be defined in the configuration file as `"actors": ["0xb4b3", "0xb0b", ...]`
+- `actor` - `Actor` contracts will be generated and all harness function calls will be proxied through these contracts. The `Actor` contracts can be considered as users of the target contracts and the functions included in these actors can be filtered by modifier, external calls, or by `payable`. This allows for granular control over user capabilities.
 
 **Example**
 

--- a/fuzz_utils/template/HarnessGenerator.py
+++ b/fuzz_utils/template/HarnessGenerator.py
@@ -113,9 +113,19 @@ class HarnessGenerator:
                     config["actors"] = self.config["actors"]
                     config["actors"][0]["targets"] = config["targets"]
             case "simple":
-                pass
+                config["actors"] = []
             case "prank":
-                pass
+                if "actors" in config:
+                    if not isinstance(config["actors"], list[str]) or len(config["actors"]) > 0:  # type: ignore[misc]
+                        CryticPrint().print_warning(
+                            "Actors not defined. Using default 0xb4b3 and 0xb0b."
+                        )
+                        config["actors"] = ["0xb4b3", "0xb0b"]
+                else:
+                    CryticPrint().print_warning(
+                        "Actors not defined. Using default 0xb4b3 and 0xb0b."
+                    )
+                    config["actors"] = ["0xb4b3", "0xb0b"]
             case _:
                 handle_exit(f"Invalid template mode {config['mode']} was provided.")
 
@@ -145,28 +155,27 @@ class HarnessGenerator:
         # Generate the Attacks
         attacks: list[Actor] = self._generate_attacks()
         CryticPrint().print_success("    Attacks generated!")
+        actors: list = []
 
         # Generate actors and harnesses, depending on strategy
         match self.mode:
             case "actor":
                 # Generate the Actors
-                actors: list[Actor] = self._generate_actors()
+                actors = self._generate_actors()
                 CryticPrint().print_success("    Actors generated!")
-
-                # Generate the harness
-                self._generate_harness_with_actors(actors, attacks)
-            case "simple":
-                # Generate the harness
-                self._generate_harness_simple_or_prank([], attacks)
             case "prank":
-                # Generate the harness
-                self._generate_harness_simple_or_prank(self.config["actors"], attacks)
+                actors = self.config["actors"]
+            case _:
+                pass
+
+        # Generate the harness
+        self._generate_harness(actors, attacks)
 
         CryticPrint().print_success("    Harness generated!")
         CryticPrint().print_success(f"Files saved to {self.config['outputDir']}")
 
-    # pylint: disable=too-many-locals,too-many-branches
-    def _generate_harness_simple_or_prank(self, actors: list, attacks: list[Actor]) -> None:
+    # pylint: disable=too-many-locals,too-many-statements,too-many-branches
+    def _generate_harness(self, actors: list, attacks: list[Actor]) -> None:
         CryticPrint().print_information(f"Generating {self.config['name']} Harness")
 
         # Generate inheritance and variables
@@ -178,7 +187,11 @@ class HarnessGenerator:
             variables.append(f"{contract.name} {contract.name.lower()};")
 
         # Generate actor variables and imports
-        if self.mode == "prank":
+        if self.mode == "actor":
+            for actor in actors:
+                variables.append(f"Actor{actor.name}[] {actor.name}_actors;")
+                imports.append(f'import "{actor.path}";')
+        elif self.mode == "prank":
             variables.append("address[] pranked_actors;")
 
         # Generate attack variables and imports
@@ -198,12 +211,24 @@ class HarnessGenerator:
             inputs_str: str = ", ".join(inputs)
             constructor += f"        {contract.name.lower()} = new {contract.name}({inputs_str});\n"
 
-        if self.mode == "prank":
+        if self.mode == "actor":
             for actor in actors:
                 constructor += "        for(uint256 i; i < 3; i++) {\n"
+                constructor_arguments = ""
+                if actor.contract and hasattr(actor.contract.constructor, "parameters"):
+                    constructor_arguments = ", ".join(
+                        [
+                            f"address({x.name.strip('_')})"
+                            for x in actor.contract.constructor.parameters
+                        ]
+                    )
                 constructor += (
-                    f"            pranked_actors.push(address({actor}));\n" + "        }\n"
+                    f"            {actor.name}_actors.push(new Actor{actor.name}({constructor_arguments}));\n"
+                    + "        }\n"
                 )
+        elif self.mode == "prank":
+            for actor in actors:
+                constructor += f"        pranked_actors.push(address({actor}));\n"
 
         for attack in attacks:
             constructor_arguments = ""
@@ -221,113 +246,26 @@ class HarnessGenerator:
 
         # Generate Functions
         functions: list[str] = []
-        for contract in self.targets:
-            function_body = ""
-            appended_params = []
-            if self.mode == "prank":
-                function_body = "        address selectedActor = pranked_actors[clampBetween(actorIndex, 0, pranked_actors.length - 1)];\n"
-                function_body += "        hevm.prank(selectedActor);\n"
-                appended_params.append("uint256 actorIndex")
-
-            temp_list = self._generate_functions(
-                contract, None, appended_params, function_body, contract.name.lower()
-            )
-            functions.extend(temp_list)
-
-        for attack in attacks:
-            temp_list = self._generate_functions(
-                attack.contract, None, [], None, f"{attack.name.lower()}Attack"
-            )
-            functions.extend(temp_list)
-
-        # Generate harness class
-        harness = Harness(
-            name=self.config["name"],
-            constructor=constructor,
-            dependencies=dependencies,
-            content="",
-            path="",
-            targets=self.targets,
-            actors=actors,
-            imports=imports,
-            variables=variables,
-            functions=functions,
-        )
-
-        content, path = self._render_template(
-            templates["HARNESS"], "harnesses", self.config["name"], harness
-        )
-        harness.set_content(content)
-        harness.set_path(path)
-
-    # pylint: disable=too-many-locals
-    def _generate_harness_with_actors(self, actors: list[Actor], attacks: list[Actor]) -> None:
-        CryticPrint().print_information(f"Generating {self.config['name']} Harness")
-
-        # Generate inheritance and variables
-        imports: list[str] = []
-        variables: list[str] = []
-
-        for contract in self.targets:
-            imports.append(f'import "{contract.source_mapping.filename.relative}";')
-            variables.append(f"{contract.name} {contract.name.lower()};")
-
-        # Generate actor variables and imports
-        for actor in actors:
-            variables.append(f"Actor{actor.name}[] {actor.name}_actors;")
-            imports.append(f'import "{actor.path}";')
-
-        # Generate attack variables and imports
-        for attack in attacks:
-            variables.append(f"Attack{attack.name} {attack.name.lower()}Attack;")
-            imports.append(f'import "{attack.path}";')
-
-        # Generate constructor with contract, actor, and attack deployment
-        constructor = "constructor() {\n"
-        for contract in self.targets:
-            inputs: list[str] = []
-            if contract.constructor:
-                constructor_parameters = contract.constructor.parameters
-                for param in constructor_parameters:
-                    constructor += f"        {param.type} {param.name};\n"
-                    inputs.append(param.name)
-            inputs_str: str = ", ".join(inputs)
-            constructor += f"        {contract.name.lower()} = new {contract.name}({inputs_str});\n"
-
-        for actor in actors:
-            constructor += "        for(uint256 i; i < 3; i++) {\n"
-            constructor_arguments = ""
-            if actor.contract and hasattr(actor.contract.constructor, "parameters"):
-                constructor_arguments = ", ".join(
-                    [f"address({x.name.strip('_')})" for x in actor.contract.constructor.parameters]
+        if self.mode == "actor":
+            for actor in actors:
+                function_body = f"        {actor.contract.name} selectedActor = {actor.name}_actors[clampBetween(actorIndex, 0, {actor.name}_actors.length - 1)];\n"
+                temp_list = self._generate_functions(
+                    actor.contract, None, ["uint256 actorIndex"], function_body, "selectedActor"
                 )
-            constructor += (
-                f"            {actor.name}_actors.push(new Actor{actor.name}({constructor_arguments}));\n"
-                + "        }\n"
-            )
+                functions.extend(temp_list)
+        else:
+            for contract in self.targets:
+                function_body = ""
+                appended_params = []
+                if self.mode == "prank":
+                    function_body = "        address selectedActor = pranked_actors[clampBetween(actorIndex, 0, pranked_actors.length - 1)];\n"
+                    function_body += "        hevm.prank(selectedActor);\n"
+                    appended_params.append("uint256 actorIndex")
 
-        for attack in attacks:
-            constructor_arguments = ""
-            if attack.contract and hasattr(attack.contract.constructor, "parameters"):
-                constructor_arguments = ", ".join(
-                    [
-                        f"address({x.name.strip('_')})"
-                        for x in attack.contract.constructor.parameters
-                    ]
+                temp_list = self._generate_functions(
+                    contract, None, appended_params, function_body, contract.name.lower()
                 )
-            constructor += f"        {attack.name.lower()}Attack = new {attack.name}({constructor_arguments});\n"
-        constructor += "    }\n"
-        # Generate dependencies
-        dependencies: str = "PropertiesAsserts"
-
-        # Generate Functions
-        functions: list[str] = []
-        for actor in actors:
-            function_body = f"        {actor.contract.name} selectedActor = {actor.name}_actors[clampBetween(actorIndex, 0, {actor.name}_actors.length - 1)];\n"
-            temp_list = self._generate_functions(
-                actor.contract, None, ["uint256 actorIndex"], function_body, "selectedActor"
-            )
-            functions.extend(temp_list)
+                functions.extend(temp_list)
 
         for attack in attacks:
             temp_list = self._generate_functions(

--- a/fuzz_utils/template/HarnessGenerator.py
+++ b/fuzz_utils/template/HarnessGenerator.py
@@ -3,7 +3,6 @@
 import os
 import copy
 from dataclasses import dataclass
-from eth_utils import to_checksum_address
 
 from slither import Slither
 from slither.core.declarations.contract import Contract
@@ -106,7 +105,9 @@ class HarnessGenerator:
         match config["mode"]:
             case "actor":
                 if "actors" in config:
-                    config["actors"] = check_and_populate_actor_fields(config["actors"], config["targets"])
+                    config["actors"] = check_and_populate_actor_fields(
+                        config["actors"], config["targets"]
+                    )
                 else:
                     CryticPrint().print_warning("Using default values for the Actor.")
                     config["actors"] = self.config["actors"]
@@ -164,7 +165,7 @@ class HarnessGenerator:
         CryticPrint().print_success("    Harness generated!")
         CryticPrint().print_success(f"Files saved to {self.config['outputDir']}")
 
-    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals,too-many-branches
     def _generate_harness_simple_or_prank(self, actors: list, attacks: list[Actor]) -> None:
         CryticPrint().print_information(f"Generating {self.config['name']} Harness")
 
@@ -175,7 +176,7 @@ class HarnessGenerator:
         for contract in self.targets:
             imports.append(f'import "{contract.source_mapping.filename.relative}";')
             variables.append(f"{contract.name} {contract.name.lower()};")
-        
+
         # Generate actor variables and imports
         if self.mode == "prank":
             variables.append("address[] pranked_actors;")
@@ -201,15 +202,17 @@ class HarnessGenerator:
             for actor in actors:
                 constructor += "        for(uint256 i; i < 3; i++) {\n"
                 constructor += (
-                    f"            pranked_actors.push(address({actor}));\n"
-                    + "        }\n"
+                    f"            pranked_actors.push(address({actor}));\n" + "        }\n"
                 )
 
         for attack in attacks:
             constructor_arguments = ""
             if attack.contract and hasattr(attack.contract.constructor, "parameters"):
                 constructor_arguments = ", ".join(
-                    [f"address({x.name.strip('_')})" for x in attack.contract.constructor.parameters]
+                    [
+                        f"address({x.name.strip('_')})"
+                        for x in attack.contract.constructor.parameters
+                    ]
                 )
             constructor += f"        {attack.name.lower()}Attack = new {attack.name}({constructor_arguments});\n"
         constructor += "    }\n"
@@ -307,7 +310,10 @@ class HarnessGenerator:
             constructor_arguments = ""
             if attack.contract and hasattr(attack.contract.constructor, "parameters"):
                 constructor_arguments = ", ".join(
-                    [f"address({x.name.strip('_')})" for x in attack.contract.constructor.parameters]
+                    [
+                        f"address({x.name.strip('_')})"
+                        for x in attack.contract.constructor.parameters
+                    ]
                 )
             constructor += f"        {attack.name.lower()}Attack = new {attack.name}({constructor_arguments});\n"
         constructor += "    }\n"

--- a/fuzz_utils/templates/default_config.py
+++ b/fuzz_utils/templates/default_config.py
@@ -12,6 +12,7 @@ default_config: dict = {
     },
     "template": {
         "name": "DefaultHarness",
+        "mode": "simple",
         "targets": [],
         "outputDir": "./test/fuzzing",
         "compilationPath": ".",

--- a/fuzz_utils/templates/harness_templates.py
+++ b/fuzz_utils/templates/harness_templates.py
@@ -29,6 +29,7 @@ __HARNESS_TEMPLATE: str = (
 /// --------------------------------------------------------------------
 
 import "{{remappings["properties"]}}util/PropertiesHelper.sol";
+import "{{remappings["properties"]}}util/Hevm.sol";
 {% for import in target.imports -%}
 {{import}}
 {% endfor %}

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -13,6 +13,7 @@ from fuzz_utils.template.HarnessGenerator import HarnessGenerator
 TEST_DATA_DIR = Path(__file__).resolve().parent / "test_data"
 default_config = {
     "name": "DefaultHarness",
+    "mode": "actor",
     "compilationPath": ".",
     "targets": [],
     "outputDir": "./test/fuzzing",


### PR DESCRIPTION
This PR adds three different strategies for generating fuzzing harnesses via the `template` command. Related to https://github.com/crytic/fuzz-utils/issues/37

The three modes are:
- `simple` - The fuzzing harness will be generated with all of the state-changing functions from the target contracts. All function calls are performed directly, with the harness contract as the `msg.sender`.
- `prank` - Similar to `simple` mode, with the difference that function calls are made from different users by using `hevm.prank()`. The users can be defined in the configuration file as `"actors": ["0xb4b3", "0xb0b", ...]`
- `actor` - `Actor` contracts will be generated and all harness function calls will be proxied through these contracts. The `Actor` contracts can be considered as users of the target contracts and the functions included in these actors can be filtered by modifier, external calls, or by `payable`. This allows for granular control over user capabilities.

### Changes
- Added a new CLI flag `--mode` to the `template` command. Added three modes: `simple`, `prank`, and `actor`
- Updated the HarnessGenerator class to enable mode selection
- Fixed harness test
- Updated README
- Updated template to import Hevm from properties