### PR TITLE
Improve unit test generation CLI arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,21 +40,21 @@ The available tool commands are:
 The `generate` command is used to generate Foundry unit tests from Echidna or Medusa corpus call sequences.
 
 **Command-line options:**
-- `compilation_path`: The path to the Solidity file or Foundry directory
-- `-cd`/`--corpus-dir` `path_to_corpus_dir`: The path to the corpus directory relative to the working directory.
-- `-c`/`--contract` `contract_name`: The name of the target contract.
-- `-td`/`--test-directory` `path_to_test_directory`: The path to the test directory relative to the working directory.
-- `-i`/`--inheritance-path` `relative_path_to_contract`: The relative path from the test directory to the contract (used for inheritance).
-- `-f`/`--fuzzer` `fuzzer_name`: The name of the fuzzer, currently supported: `echidna` and `medusa`
-- `--named-inputs`: Includes function input names when making calls
-- `--config`: Path to the fuzz-utils config JSON file
-- `--all-sequences`: Include all corpus sequences when generating unit tests.
+- `compilation_path`: The path to the Solidity file or Foundry directory. By default `.`
+- `-cd`/`--corpus-dir` `path_to_corpus_dir`: The path to the corpus directory relative to the working directory. By default `corpus`
+- `-c`/`--contract` `contract_name`: The name of the target contract. If the compilation path only contains one contract the target will be automatically derived.
+- `-td`/`--test-directory` `path_to_test_directory`: The path to the test directory relative to the working directory. By default `test`
+- `-i`/`--inheritance-path` `relative_path_to_contract`: The relative path from the test directory to the contract (used for overriding inheritance). If this configuration option is not provided the inheritance path will be automatically derived. 
+- `-f`/`--fuzzer` `fuzzer_name`: The name of the fuzzer, currently supported: `echidna` and `medusa`. By default `medusa`
+- `--named-inputs`: Includes function input names when making calls. By default`false`
+- `--config`: Path to the fuzz-utils config JSON file. Empty by default.
+- `--all-sequences`: Include all corpus sequences when generating unit tests. By default `false`
 
 **Example**
 
 In order to generate a test file for the [BasicTypes.sol](tests/test_data/src/BasicTypes.sol) contract, based on the Echidna corpus reproducers for this contract ([corpus-basic](tests/test_data/echidna-corpora/corpus-basic/)), we need to `cd` into the `tests/test_data` directory which contains the Foundry project and run the command:
 ```bash
-fuzz-utils generate ./src/BasicTypes.sol --corpus-dir echidna-corpora/corpus-basic --contract "BasicTypes" --test-directory "./test/" --inheritance-path "../src/" --fuzzer echidna
+fuzz-utils generate ./src/BasicTypes.sol --corpus-dir echidna-corpora/corpus-basic --contract "BasicTypes" --fuzzer echidna
 ```
 
 Running this command should generate a `BasicTypes_Echidna_Test.sol` file in the [test](/tests/test_data/test/) directory of the Foundry project.

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ The `template` command is used to generate a fuzzing harness. The harness can in
 
 **Command-line options:**
 - `compilation_path`: The path to the Solidity file or Foundry directory
-- `-n`/`--name` `name: str`: The name of the fuzzing harness.
-- `-c`/`--contracts` `target_contracts: list`: The name of the target contract.
-- `-o`/`--output-dir` `output_directory: str`: Output directory name. By default it is `fuzzing`
+- `-n`/`--name` `name: str`: The name of the fuzzing harness. By default `DefaultHarness`
+- `-c`/`--contracts` `target_contracts: list`: The name of the target contract. Empty by default.
+- `-o`/`--output-dir` `output_directory: str`: Output directory name. By default `fuzzing`
 - `--config`: Path to the `fuzz-utils` config JSON file
 - `--mode`: The strategy to use when generating the harnesses. Valid options: `simple`, `prank`, `actor`
 

--- a/fuzz_utils/generate/FoundryTest.py
+++ b/fuzz_utils/generate/FoundryTest.py
@@ -69,8 +69,8 @@ class FoundryTest:
         # 4. Generate the test file
         template = jinja2.Template(templates["CONTRACT"])
         write_path = os.path.join(self.test_dir, self.target_name)
-        inheritance_path = os.path.join(self.inheritance_path, self.target_file_name)
-
+        inheritance_path = os.path.join(self.inheritance_path)
+        print("INHERITANCE PATH", inheritance_path)
         # 5. Save the test file
         test_file_str = template.render(
             file_path=inheritance_path,

--- a/fuzz_utils/generate/FoundryTest.py
+++ b/fuzz_utils/generate/FoundryTest.py
@@ -1,12 +1,14 @@
 """The FoundryTest class that handles generation of unit tests from call sequences"""
 import os
 import json
+import copy
 from typing import Any
 import jinja2
 
 from slither import Slither
 from fuzz_utils.utils.crytic_print import CryticPrint
 from fuzz_utils.utils.slither_utils import get_target_contract
+from fuzz_utils.templates.default_config import default_config
 
 from fuzz_utils.generate.fuzzers.Medusa import Medusa
 from fuzz_utils.generate.fuzzers.Echidna import Echidna
@@ -18,19 +20,20 @@ class FoundryTest:
     Handles the generation of Foundry test files
     """
 
+    config: dict = copy.deepcopy(default_config["generate"])
+
     def __init__(
         self,
         config: dict,
         slither: Slither,
         fuzzer: Echidna | Medusa,
     ) -> None:
-        self.inheritance_path = config["inheritancePath"]
-        self.target_name = config["targetContract"]
-        self.corpus_path = config["corpusDir"]
-        self.test_dir = config["testsDir"]
-        self.all_sequences = config["allSequences"]
         self.slither = slither
-        self.target = get_target_contract(self.slither, self.target_name)
+        for key, value in config.items():
+            if key in self.config:
+                self.config[key] = value
+
+        self.target = get_target_contract(self.slither, self.config["targetContract"])
         self.target_file_name = self.target.source_mapping.filename.relative.split("/")[-1]
         self.fuzzer = fuzzer
 
@@ -40,7 +43,7 @@ class FoundryTest:
         file_list: list[dict[str, Any]] = []
         tests_list = []
         dir_list = []
-        if self.all_sequences:
+        if self.config["allSequences"]:
             dir_list = self.fuzzer.corpus_dirs
         else:
             dir_list = [self.fuzzer.reproducer_dir]
@@ -68,13 +71,12 @@ class FoundryTest:
 
         # 4. Generate the test file
         template = jinja2.Template(templates["CONTRACT"])
-        write_path = os.path.join(self.test_dir, self.target_name)
-        inheritance_path = os.path.join(self.inheritance_path)
-        print("INHERITANCE PATH", inheritance_path)
+        write_path = os.path.join(self.config["testsDir"], self.config["targetContract"])
+        inheritance_path = os.path.join(self.config["inheritancePath"])
         # 5. Save the test file
         test_file_str = template.render(
             file_path=inheritance_path,
-            target_name=self.target_name,
+            target_name=self.config["targetContract"],
             amount=0,
             tests=tests_list,
             fuzzer=self.fuzzer.name,

--- a/fuzz_utils/parsing/parser_util.py
+++ b/fuzz_utils/parsing/parser_util.py
@@ -1,0 +1,31 @@
+"""Utility functions used in the command parsers"""
+import json
+from fuzz_utils.utils.error_handler import handle_exit
+
+
+def check_config_and_set_default_values(
+    config: dict, fields: list[str], defaults: list[str]
+) -> None:
+    """Checks that the configuration dictionary contains a non-empty field"""
+    assert len(fields) == len(defaults)
+    for idx, field in enumerate(fields):
+        if field not in config or len(config[field]) == 0:
+            config[field] = defaults[idx]
+
+
+def check_configuration_field_exists_and_non_empty(config: dict, command: str, field: str) -> None:
+    """Checks that the configuration dictionary contains a non-empty field"""
+    if field not in config or len(config[field]) == 0:
+        handle_exit(f"The {command} configuration field {field} is not configured.")
+
+
+def open_config(cli_config: str, command: str) -> dict:
+    """Open config file if provided return its contents"""
+    with open(cli_config, "r", encoding="utf-8") as readFile:
+        complete_config = json.load(readFile)
+        if command in complete_config:
+            return complete_config[command]
+
+        handle_exit(
+            f"The provided configuration file does not contain the `{command}` command configuration field."
+        )

--- a/fuzz_utils/template/HarnessGenerator.py
+++ b/fuzz_utils/template/HarnessGenerator.py
@@ -15,6 +15,7 @@ from fuzz_utils.utils.file_manager import check_and_create_dirs, save_file
 from fuzz_utils.utils.error_handler import handle_exit
 from fuzz_utils.utils.slither_utils import get_target_contract
 from fuzz_utils.templates.harness_templates import templates
+from fuzz_utils.templates.default_config import default_config
 
 # pylint: disable=too-many-instance-attributes
 @dataclass
@@ -76,26 +77,7 @@ class HarnessGenerator:
     Handles the generation of Foundry test files from Echidna reproducers
     """
 
-    config: dict = {
-        "name": "DefaultHarness",
-        "compilationPath": ".",
-        "targets": [],
-        "outputDir": "./test/fuzzing",
-        "actors": [
-            {
-                "name": "Default",
-                "targets": [],
-                "number": 3,
-                "filters": {
-                    "strict": False,
-                    "onlyModifiers": [],
-                    "onlyPayable": False,
-                    "onlyExternalCalls": [],
-                },
-            }
-        ],
-        "attacks": [],
-    }
+    config: dict = copy.deepcopy(default_config["template"])
 
     def __init__(
         self,

--- a/fuzz_utils/template/HarnessGenerator.py
+++ b/fuzz_utils/template/HarnessGenerator.py
@@ -13,6 +13,7 @@ import jinja2
 from fuzz_utils.utils.crytic_print import CryticPrint
 from fuzz_utils.utils.file_manager import check_and_create_dirs, save_file
 from fuzz_utils.utils.error_handler import handle_exit
+from fuzz_utils.utils.slither_utils import get_target_contract
 from fuzz_utils.templates.harness_templates import templates
 
 # pylint: disable=too-many-instance-attributes
@@ -69,6 +70,7 @@ class Harness:
         self.path = path
 
 
+# pylint: disable=too-few-public-methods
 class HarnessGenerator:
     """
     Handles the generation of Foundry test files from Echidna reproducers
@@ -140,7 +142,7 @@ class HarnessGenerator:
 
         self.slither = slither
         self.targets = [
-            self.get_target_contract(slither, contract) for contract in self.config["targets"]
+            get_target_contract(slither, contract) for contract in self.config["targets"]
         ]
         self.output_dir = self.config["outputDir"]
 
@@ -321,7 +323,7 @@ class HarnessGenerator:
                 attack.set_path(path)
 
                 attack_slither = Slither(f"{attack_output_path}/Attack{name}.sol")
-                attack.set_contract(self.get_target_contract(attack_slither, f"{name}Attack"))
+                attack.set_contract(get_target_contract(attack_slither, f"{name}Attack"))
 
                 attacks.append(attack)
             else:
@@ -392,8 +394,7 @@ class HarnessGenerator:
         for actor_config in self.config["actors"]:
             name = actor_config["name"]
             target_contracts: list[Contract] = [
-                self.get_target_contract(self.slither, contract)
-                for contract in actor_config["targets"]
+                get_target_contract(self.slither, contract) for contract in actor_config["targets"]
             ]
 
             CryticPrint().print_information(f"    Actor: {name}Actor...")
@@ -409,7 +410,7 @@ class HarnessGenerator:
             actor.set_path(path)
 
             actor_slither = Slither(f"{actor_output_path}/Actor{name}.sol")
-            actor.set_contract(self.get_target_contract(actor_slither, f"Actor{name}"))
+            actor.set_contract(get_target_contract(actor_slither, f"Actor{name}"))
 
             actor_contracts.append(actor)
 
@@ -518,17 +519,6 @@ class HarnessGenerator:
         save_file(output_path, f"/{file_name}", ".sol", content)
 
         return content, f"../{directory_name}/{file_name}.sol"
-
-    # pylint: disable=no-self-use
-    def get_target_contract(self, slither: Slither, target_name: str) -> Contract:
-        """Finds and returns Slither Contract"""
-        contracts = slither.get_contract_from_name(target_name)
-        # Loop in case slither fetches multiple contracts for some reason (e.g., similar names?)
-        for contract in contracts:
-            if contract.name == target_name:
-                return contract
-
-        handle_exit(f"\n* Slither could not find the specified contract `{target_name}`.")
 
 
 # Utility functions

--- a/fuzz_utils/templates/default_config.py
+++ b/fuzz_utils/templates/default_config.py
@@ -3,9 +3,9 @@ default_config: dict = {
     "generate": {
         "targetContract": "",
         "compilationPath": ".",
-        "corpusDir": "",
-        "fuzzer": "",
-        "testsDir": "",
+        "corpusDir": "corpus",
+        "fuzzer": "medusa",
+        "testsDir": "test",
         "inheritancePath": "",
         "namedInputs": False,
         "allSequences": False,

--- a/fuzz_utils/utils/slither_utils.py
+++ b/fuzz_utils/utils/slither_utils.py
@@ -1,0 +1,15 @@
+"""Common utilities for Slither"""
+from slither import Slither
+from slither.core.declarations.contract import Contract
+from fuzz_utils.utils.error_handler import handle_exit
+
+
+def get_target_contract(slither: Slither, target_name: str) -> Contract:
+    """Gets the Slither Contract object for the specified contract file"""
+    contracts = slither.get_contract_from_name(target_name)
+    # Loop in case slither fetches multiple contracts for some reason (e.g., similar names?)
+    for contract in contracts:
+        if contract.name == target_name:
+            return contract
+
+    handle_exit(f"\n* Slither could not find the specified contract `{target_name}`.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ class TestGenerator:
         medusa = Medusa(target, f"medusa-corpora/{corpus_dir}", slither, False)
         config = {
             "targetContract": target,
-            "inheritancePath": "../src/",
+            "inheritancePath": f"../src/{target}.sol",
             "corpusDir": f"echidna-corpora/{corpus_dir}",
             "testsDir": "./test/",
             "allSequences": False,

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -7,6 +7,7 @@ from slither import Slither
 from slither.core.declarations.contract import Contract
 from slither.core.declarations.function_contract import FunctionContract
 from fuzz_utils.utils.remappings import find_remappings
+from fuzz_utils.utils.slither_utils import get_target_contract
 
 from fuzz_utils.template.HarnessGenerator import HarnessGenerator
 
@@ -208,7 +209,7 @@ def run_harness(
 
     # Ensure the harness only contains the functions we're expecting
     slither = Slither(f"./test/fuzzing/harnesses/{harness_name}.sol")
-    target: Contract = generator.get_target_contract(slither, harness_name)
+    target: Contract = get_target_contract(slither, harness_name)
     compare_with_declared_functions(target, set(expected_functions))
 
 


### PR DESCRIPTION
This PR addresses issue https://github.com/crytic/fuzz-utils/issues/39.

### Changes
- CLI arguments of the `generate` command were made optional. The target contract and the inheritance path can be automatically derived, the rest have default values now.
- The default config in the `HarnessGenerator` and `FoundryTest` classes is now deep copied from the default_config template instead of redefined.
- Fixed test failure due to changes to CLI argument derivation
- Updated README
