### PR TITLE
Add tool to modify fuzzer corpora

### DIFF
--- a/fuzz_utils/modify_corpus/CorpusModifier.py
+++ b/fuzz_utils/modify_corpus/CorpusModifier.py
@@ -1,28 +1,34 @@
 """The CorpusModifier class handles modification of corpus call sequences based on fuzzer config"""
 import os
-import yaml
 import hashlib
 import json
 import shutil
-import copy
 import datetime
+import yaml
+
 from slither import Slither
 from fuzz_utils.utils.slither_utils import get_target_contract
 from fuzz_utils.utils.error_handler import handle_exit
+from fuzz_utils.utils.crytic_print import CryticPrint
 
+# pylint: disable=too-many-instance-attributes
 class CorpusModifier:
     """
     Handles modifying the corpus based on the fuzzer configuration.
     """
-    fuzzer_fields: dict = {"echidna": ["maxTimeDelay", "maxBlockDelay", "filterFunctions"], "medusa": ["blockTimestampDelayMax", "blockNumberDelayMax"]}
-    corpora_format: dict = {"echidna": {"coverage": [], "reproducers": []}, "medusa": {"call_sequences": {"immutable": [], "mutable": []}, "test_results": []}}
+
+    fuzzer_fields: dict = {
+        "echidna": ["maxTimeDelay", "maxBlockDelay", "filterFunctions"],
+        "medusa": ["blockTimestampDelayMax", "blockNumberDelayMax"],
+    }
+    corpora_format: dict = {
+        "echidna": {"coverage": [], "reproducers": []},
+        "medusa": {"call_sequences": {"immutable": [], "mutable": []}, "test_results": []},
+    }
     valid_modes: list = ["delete_sequence", "delete_calls"]
     fuzzer_config: dict | None = None
-    def __init__(
-        self,
-        config: dict,
-        slither: Slither | None
-    ) -> None:
+
+    def __init__(self, config: dict, slither: Slither | None) -> None:
         if config:
             self.modifier_config = config
         if slither:
@@ -38,15 +44,20 @@ class CorpusModifier:
             self.mode = config["mode"]
         if "targetContract" in config:
             self.target = get_target_contract(self.slither, config["targetContract"])
-        self.corpus_copy = {}
-        self.rules_list = [self._is_incorrect_delay, self._is_blacklisted_function, self._is_nonexistent_function]
+        self.corpus_copy: list = []
+        self.rules_list = [
+            self._is_incorrect_delay,
+            self._is_blacklisted_function,
+            self._is_nonexistent_function,
+        ]
         self.modifications_list = [self._modify_invalid_caller]
-
 
     def modify_corpus(self) -> None:
         """Modifies the current corpus and saves the new version"""
         # 1. Open the corpus and parse all the files
-        self.corpus_copy = self._copy_fuzzer_corpus(self.corpora_format[self.fuzzer], self.corpus_path)
+        self.corpus_copy = self._copy_fuzzer_corpus(
+            self.corpora_format[self.fuzzer], self.corpus_path
+        )
         # 2. a) Copy current corpus somewhere in case something goes wrong?
         self.save_corpus_to_history()
         # 4. Apply the rules
@@ -56,13 +67,17 @@ class CorpusModifier:
 
     def dry_run(self) -> None:
         """Prints the calls that would be modified, without modifying them"""
-        self.corpus_copy = self._copy_fuzzer_corpus(self.corpora_format[self.fuzzer.lower()], self.corpus_path)
-        new_corpus = self._filter_corpus(self.mode, self.rules_list, self.modifications_list)
+        self.corpus_copy = self._copy_fuzzer_corpus(
+            self.corpora_format[self.fuzzer.lower()], self.corpus_path
+        )
+        _ = self._filter_corpus(self.mode, self.rules_list, self.modifications_list)
 
     def save_corpus_to_history(self) -> None:
         """Saves the current corpus directory to the corpus history"""
         # 1. Fetch current corpus
-        corpus_to_save = self._copy_fuzzer_corpus(self.corpora_format[self.fuzzer.lower()], self.corpus_path)
+        corpus_to_save = self._copy_fuzzer_corpus(
+            self.corpora_format[self.fuzzer.lower()], self.corpus_path
+        )
         # 2. Check if .fuzz_utils folder already exists, create it if not
         directory = self._create_or_fetch_hidden_directory()
         # 3. Convert into a string
@@ -86,11 +101,18 @@ class CorpusModifier:
         # 6. Add to history
         timestamp = datetime.datetime.now().isoformat()
         comment = input("Enter a comment for this save: ")
-        history[corpus_hash] = {"path": self.corpus_path, "timestamp": timestamp, "content": corpus_to_save, "comment": comment}
+        history[corpus_hash] = {
+            "path": self.corpus_path,
+            "timestamp": timestamp,
+            "content": corpus_to_save,
+            "comment": comment,
+        }
         # 7. Save history
         # TODO check if this can fail
         with open(history_path, "w", encoding="utf-8") as f:
             json.dump(history, f)
+
+        CryticPrint().print_information(f"Corpus saved to history with hash: {corpus_hash}")
 
     def restore_corpus_from_history(self, corpus_hash: str) -> None:
         """Overrides the current corpus directory with a historical version"""
@@ -120,11 +142,11 @@ class CorpusModifier:
                 for key, value in history.items():
                     print(f'{key}: {value["comment"]} (saved at {value["timestamp"]})')
             else:
-                print("No historic corpora were found.")
+                print("No historic corpora found.")
 
-
-
-    def _override_corpus_directory(self, directory_path: str, contents_list: list) -> None:
+    def _override_corpus_directory(  # pylint: disable=no-self-use
+        self, directory_path: str, contents_list: list
+    ) -> None:
         for root, dirs, files in os.walk(directory_path):
             for file in files:
                 file_path = os.path.join(root, file)
@@ -143,10 +165,11 @@ class CorpusModifier:
                 os.makedirs(directory, exist_ok=True)
 
                 # Write the file contents
-                with open(file_path, "w", encoding="utf-8") as file:
-                    json.dump(file_content, file, indent=4)
+                # TODO fix the mypy errors later on
+                with open(file_path, "w", encoding="utf-8") as file:  # type: ignore[assignment]
+                    json.dump(file_content, file, indent=4)  # type: ignore[arg-type]
 
-    def _create_or_fetch_hidden_directory(self) -> str:
+    def _create_or_fetch_hidden_directory(self) -> str:  # pylint: disable=no-self-use
         current_directory = os.getcwd()
         directory_name = os.path.join(current_directory, ".fuzz_utils")
         os.makedirs(directory_name, exist_ok=True)
@@ -162,18 +185,32 @@ class CorpusModifier:
         block_delay: int
 
         if self.fuzzer == "echidna":
-            maxTimeDelay = self.fuzzer_config["maxTimeDelay"] if "maxTimeDelay" in self.fuzzer_config else None
-            maxBlockDelay = self.fuzzer_config["maxBlockDelay"] if "maxBlockDelay" in self.fuzzer_config else None
+            maxTimeDelay = (
+                self.fuzzer_config["maxTimeDelay"] if "maxTimeDelay" in self.fuzzer_config else None
+            )
+            maxBlockDelay = (
+                self.fuzzer_config["maxBlockDelay"]
+                if "maxBlockDelay" in self.fuzzer_config
+                else None
+            )
             time_delay = int(call_object["delay"][0], 16)
             block_delay = int(call_object["delay"][1], 16)
         elif self.fuzzer == "medusa":
-            maxTimeDelay = self.fuzzer_config["fuzzing"]["blockTimestampDelayMax"] if "blockTimestampDelayMax" in self.fuzzer_config["fuzzing"] else None
-            maxBlockDelay = self.fuzzer_config["fuzzing"]["blockNumberDelayMax"] if "blockNumberDelayMax" in self.fuzzer_config["fuzzing"] else None
+            maxTimeDelay = (
+                self.fuzzer_config["fuzzing"]["blockTimestampDelayMax"]
+                if "blockTimestampDelayMax" in self.fuzzer_config["fuzzing"]
+                else None
+            )
+            maxBlockDelay = (
+                self.fuzzer_config["fuzzing"]["blockNumberDelayMax"]
+                if "blockNumberDelayMax" in self.fuzzer_config["fuzzing"]
+                else None
+            )
             time_delay = call_object["blockTimestampDelay"]
             block_delay = call_object["blockNumberDelay"]
         else:
             raise ValueError(f"Invalid fuzzer: {self.fuzzer}")
-        
+
         if maxTimeDelay:
             if time_delay > maxTimeDelay:
                 return True
@@ -188,8 +225,8 @@ class CorpusModifier:
             return False
 
         function_name: str
-        #contracts = self.slither.contracts_derived
-        #functions = [y.name for x in contracts for y in x.functions_entry_points]
+        # contracts = self.slither.contracts_derived
+        # functions = [y.name for x in contracts for y in x.functions_entry_points]
         # TODO enable multiple targets later
         functions = [x.name for x in self.target.functions_entry_points]
 
@@ -212,12 +249,18 @@ class CorpusModifier:
         blacklisted_functions: list | None
         if self.fuzzer == "echidna":
             function_name = call_object["call"]["contents"][0]
-            blacklisted_functions: list | None = self.fuzzer_config["filterFunctions"] if "filterFunctions" in self.fuzzer_config else None
+            blacklisted_functions = (
+                self.fuzzer_config["filterFunctions"]
+                if "filterFunctions" in self.fuzzer_config
+                else None
+            )
         else:
             raise ValueError("Function blacklisting is only available in Echidna.")
 
         if blacklisted_functions:
-            if function_name in blacklisted_functions: # pylint: disable=unsupported-membership-test
+            if (
+                function_name in blacklisted_functions
+            ):  # pylint: disable=unsupported-membership-test
                 return True
         return False
 
@@ -235,17 +278,23 @@ class CorpusModifier:
         new_corpus: list = []
         for idx, value in enumerate(self.corpus_copy):
             # A list of files with call sequences in them
-            resulting_sequence = self._filter_call_sequence(mode, rules_list, modification_list, value["content"])
+            resulting_sequence = self._filter_call_sequence(
+                mode, rules_list, modification_list, value["content"]
+            )
 
             if resulting_sequence:
-                new_corpus.append({"path": self.corpus_copy[idx]["path"], "content": resulting_sequence})
+                new_corpus.append(
+                    {"path": self.corpus_copy[idx]["path"], "content": resulting_sequence}
+                )
         return new_corpus
 
-    def _filter_call_sequence(self, mode: str, rules_list: list, modification_list: list, call_sequence: list) -> dict | None:
-        def should_skip(call):
+    def _filter_call_sequence(
+        self, mode: str, rules_list: list, modification_list: list, call_sequence: list
+    ) -> list | None:
+        def should_skip(call: dict) -> bool:
             return any(rule_fn(call) for rule_fn in rules_list)
 
-        def replace_fields(call) -> dict:
+        def replace_fields(call: dict) -> dict:
             for modify_fn in modification_list:
                 call = modify_fn(call)
             return call
@@ -266,9 +315,8 @@ class CorpusModifier:
 
         return resulting_sequence if resulting_sequence else None
 
-
-    def _copy_fuzzer_corpus(self, corpus: dict, current_path: str) -> list | None:
-        temp_corpus = []
+    def _copy_fuzzer_corpus(self, corpus: dict, current_path: str) -> list:
+        temp_corpus: list = []
         for key in corpus.keys():
             subdir_path = os.path.join(current_path, key)
             if isinstance(corpus[key], dict):
@@ -276,7 +324,7 @@ class CorpusModifier:
             else:
                 temp_corpus.extend(self._fetch_directory_files(subdir_path))
 
-        return temp_corpus if temp_corpus else None
+        return temp_corpus
 
     def _fetch_directory_files(self, directory: str) -> list:
         file_list: list = []
@@ -288,7 +336,9 @@ class CorpusModifier:
                     try:
                         with open(full_path, "r", encoding="utf-8") as file:
                             if self.fuzzer.lower() == "echidna":
-                                file_list.append({"path": full_path, "content": yaml.safe_load(file)})
+                                file_list.append(
+                                    {"path": full_path, "content": yaml.safe_load(file)}
+                                )
                             else:
                                 file_list.append({"path": full_path, "content": json.load(file)})
                     except Exception:  # pylint: disable=broad-except
@@ -308,7 +358,7 @@ class CorpusModifier:
                         complete_config = yaml.safe_load(file)
                     else:
                         complete_config = json.load(file)["fuzzing"]
-            except Exception: # pylint: disable=broad-except
+            except Exception:  # pylint: disable=broad-except
                 handle_exit(f"Failed to find the fuzzer configuration file at {self.config_path}")
 
         for key, value in complete_config.items():
@@ -316,4 +366,3 @@ class CorpusModifier:
                 filtered_config[key] = value
 
         return filtered_config
-        

--- a/fuzz_utils/modify_corpus/CorpusModifier.py
+++ b/fuzz_utils/modify_corpus/CorpusModifier.py
@@ -1,0 +1,246 @@
+"""The CorpusModifier class handles modification of corpus call sequences based on fuzzer config"""
+import os
+import yaml
+import hashlib
+import json
+import shutil
+import copy
+import datetime
+from slither import Slither
+from fuzz_utils.utils.error_handler import handle_exit
+
+class CorpusModifier:
+    """
+    Handles modifying the corpus based on the fuzzer configuration.
+    """
+    fuzzer_fields: dict
+    corpora_format: dict = {"echidna": {"coverage": [], "reproducers": []}, "medusa": {"call_sequences": {"immutable": [], "mutable": []}, "test_results": []}}
+
+    def __init__(
+        self,
+        config_path: str | None,
+        corpus_path: str | None,
+        slither: Slither | None,
+        fuzzer: str | None,
+    ) -> None:
+        self.fuzzer_fields = {}
+        if slither:
+            self.slither = slither
+        if corpus_path:
+            self.corpus_path = corpus_path
+        if fuzzer:
+            self.fuzzer = fuzzer
+            self.fuzzer_fields["echidna"] = ["maxTimeDelay", "maxBlockDelay", "filterFunctions"]
+        if config_path:
+            self.config_path = config_path
+            self.fuzzer_config = self._fetch_fuzzer_config(self.fuzzer_fields[fuzzer])
+        self.corpus_copy = {}
+    
+    def modify_corpus(self) -> None:
+        """Modifies the current corpus and saves the new version"""
+        # 1. Open the corpus and parse all the files
+        self.corpus_copy = self._copy_fuzzer_corpus(self.corpora_format[self.fuzzer.lower()], self.corpus_path)
+        # 2. a) Copy current corpus somewhere in case something goes wrong?
+        self.save_corpus_to_history()
+        # 3. Define list of rules to apply
+        # TODO update this later to be dynamic
+        rules_list = [self._is_incorrect_delay]
+        # 4. Apply the rules
+        self._filter_corpus("filters_calls", rules_list)
+        # 5. Save the new corpus
+        self._override_corpus_directory(self.corpus_path, self.corpus_copy)
+
+    def save_corpus_to_history(self) -> None:
+        """Saves the current corpus directory to the corpus history"""
+        # 1. Fetch current corpus
+        corpus_to_save = self._copy_fuzzer_corpus(self.corpora_format[self.fuzzer.lower()], self.corpus_path)
+        # 2. Check if .fuzz_utils folder already exists, create it if not
+        directory = self._create_or_fetch_hidden_directory()
+        # 3. Convert into a string
+        corpus_str = json.dumps(corpus_to_save, sort_keys=True)
+        # 4. Hash it
+        corpus_hash = hashlib.sha256(corpus_str.encode()).hexdigest()
+        # 5. Check if hash already exists, skip operation and print a message if it does
+        history: dict
+        history_path = os.path.join(directory, "history.json")
+        # TODO check if this can fail
+        if not os.path.exists(history_path):
+            with open(history_path, "w", encoding="utf-8") as f:
+                f.write("{}")
+
+        with open(history_path, "r", encoding="utf-8") as f:
+            history = json.load(f)
+        
+        if corpus_hash in history.keys():
+            print(f"The corpus is already saved to history with the hash {corpus_hash}")
+            return
+        # 6. Add to history
+        timestamp = datetime.datetime.now().isoformat()
+        comment = input("Enter a comment for this save: ")
+        history[corpus_hash] = {"path": self.corpus_path, "timestamp": timestamp, "content": corpus_to_save, "comment": comment}
+        # 7. Save history
+        # TODO check if this can fail
+        with open(history_path, "w", encoding="utf-8") as f:
+            json.dump(history, f)
+    
+    def restore_corpus_from_history(self, corpus_hash: str) -> None:
+        """Overrides the current corpus directory with a historical version"""
+        directory = self._create_or_fetch_hidden_directory()
+        history_path = os.path.join(directory, "history.json")
+        fetched_corpus: dict
+        # TODO check if this can fail
+        with open(history_path, "r", encoding="utf-8") as f:
+            history = json.load(f)
+        
+            if corpus_hash in history.keys():
+                fetched_corpus = history[corpus_hash]
+                self._override_corpus_directory(fetched_corpus["path"], fetched_corpus["content"])
+            else:
+                handle_exit("The provided hash was not found.")
+
+    def list_historic_corpora(self) -> None:
+        """Prints all the saved corpora"""
+        directory = self._create_or_fetch_hidden_directory()
+        history_path = os.path.join(directory, "history.json")
+
+        with open(history_path, "r", encoding="utf-8") as f:
+            history = json.load(f)
+
+            if history:
+                print("History:\n")
+                for key, value in history.items():
+                    print(f'{key}: {value["comment"]} (saved at {value["timestamp"]})')
+            else:
+                print("No historic corpora were found.")
+
+
+
+    def _override_corpus_directory(self, directory_path: str, contents_list: list) -> None:
+        for root, dirs, files in os.walk(directory_path):
+            for file in files:
+                file_path = os.path.join(root, file)
+                os.remove(file_path)
+            for directory in dirs:
+                dir_path = os.path.join(root, directory)
+                shutil.rmtree(dir_path)
+
+        for item in contents_list:
+            file_path = item["path"]
+            file_content = item["content"]
+
+            if file_content:
+                # Ensure the directory exists
+                directory = os.path.dirname(file_path)
+                os.makedirs(directory, exist_ok=True)
+
+                # Write the file contents
+                with open(file_path, "w", encoding="utf-8") as file:
+                    json.dump(file_content, file, indent=4)
+
+    def _create_or_fetch_hidden_directory(self) -> str:
+        current_directory = os.getcwd()
+        directory_name = os.path.join(current_directory, ".fuzz_utils")
+        os.makedirs(directory_name, exist_ok=True)
+        return directory_name
+
+
+
+    # TODO only supports Echidna for now
+    def _is_incorrect_delay(self, call_object: dict) -> bool:
+        maxTimeDelay = self.fuzzer_config["maxTimeDelay"] if "maxTimeDelay" in self.fuzzer_config else None
+        maxBlockDelay = self.fuzzer_config["maxBlockDelay"] if "maxBlockDelay" in self.fuzzer_config else None
+
+        if maxTimeDelay:
+            time_delay = int(call_object["delay"][0], 16)
+            if time_delay > maxTimeDelay:
+                return True
+        if maxBlockDelay:
+            block_delay = int(call_object["delay"][1], 16)
+            if block_delay > maxBlockDelay:
+                return True
+
+        return False
+
+    def _filter_corpus(self, mode: str, rules_list: list) -> None:
+        for idx, value in enumerate(self.corpus_copy):
+            sequence_list: list = []
+            # A list of files with call sequences in them
+            for call_sequence in value["content"]:
+                resulting_sequence = self._filter_call_sequence(mode, rules_list, call_sequence)
+
+                if resulting_sequence:
+                    sequence_list.append(resulting_sequence)
+
+            # Override the old call sequences with the new ones
+            self.corpus_copy[idx] = {"path": self.corpus_copy[idx]["path"], "content": sequence_list}
+
+    def _filter_call_sequence(self, mode: str, rules_list: list, call_sequence: list) -> dict | None:
+        def should_skip(call):
+            return any(rule_fn(call) for rule_fn in rules_list)
+
+        if mode not in {"delete_sequence", "filter_calls"}:
+            raise ValueError("Invalid mode")
+
+        resulting_sequence: dict = {"name": call_sequence["name"], "content": []}
+
+        for call in call_sequence["content"]:
+            if should_skip(call):
+                if mode == "delete_sequence":
+                    return None
+            else:
+                resulting_sequence["content"].append(call)
+
+        return resulting_sequence if resulting_sequence["content"] else None
+
+
+    def _copy_fuzzer_corpus(self, corpus: dict, current_path: str) -> list | None:
+        temp_corpus = []
+        for key in corpus.keys():
+            subdir_path = os.path.join(current_path, key)
+            if isinstance(corpus[key], dict):
+                temp_corpus[key] = self._copy_fuzzer_corpus(corpus[key], subdir_path)
+            else:
+                temp_corpus.extend(self._fetch_directory_files(subdir_path))
+
+        return temp_corpus if temp_corpus else None
+
+    def _fetch_directory_files(self, directory: str) -> list:
+        file_list: list = []
+        if os.path.exists(directory):
+            for entry in os.listdir(directory):
+                full_path = os.path.join(directory, entry)
+
+                if os.path.isfile(full_path):
+                    try:
+                        with open(full_path, "r", encoding="utf-8") as file:
+                            if self.fuzzer.lower() == "echidna":
+                                file_list.append({"path": full_path, "content": yaml.safe_load(file)})
+                            else:
+                                file_list.append({"path": full_path, "content": json.load(file)})
+                    except Exception:  # pylint: disable=broad-except
+                        print(f"Fail on {full_path}")
+        else:
+            print(f"The provided corpus path does not exists: {directory}. Skipping.")
+
+        return file_list
+
+    def _fetch_fuzzer_config(self, fields: list[str]) -> dict:
+        filtered_config: dict = {}
+        complete_config: dict
+        if os.path.isfile(self.config_path):
+            try:
+                with open(self.config_path, "r", encoding="utf-8") as file:
+                    if self.fuzzer.lower() == "echidna":
+                        complete_config = yaml.safe_load(file)
+                    else:
+                        complete_config = json.load(file)
+            except Exception: # pylint: disable=broad-except
+                handle_exit(f"Failed to find the fuzzer configuration file at {self.config_path}")
+
+        for key, value in complete_config.items():
+            # TODO won't work for Medusa
+            if key in fields:
+                filtered_config[key] = value
+
+        return filtered_config
+        

--- a/fuzz_utils/parsing/commands/modify_corpus.py
+++ b/fuzz_utils/parsing/commands/modify_corpus.py
@@ -4,7 +4,7 @@ from slither import Slither
 from fuzz_utils.utils.crytic_print import CryticPrint
 from fuzz_utils.modify_corpus.CorpusModifier import CorpusModifier
 from fuzz_utils.utils.error_handler import handle_exit
-from fuzz_utils.parsing.parser_util import check_config_and_set_default_values, open_config
+from fuzz_utils.parsing.parser_util import check_config_and_set_default_values
 
 COMMAND: str = "modify-corpus"
 
@@ -81,14 +81,16 @@ def modify_command(args: Namespace) -> None:
         config["modifySenders"] = {}
         # Process list
         for item in args.modify_senders:
-            assert("=" in item)
+            assert "=" in item
             senders = item.split("=")
             config["modifySenders"][senders[0]] = senders[1]
     if args.filter_functions:
         config["filterFunctions"] = args.filter_functions
     if args.dry_run:
         config["dryRun"] = args.dry_run
-        CryticPrint().print_error("The --dry-run command isn't implemented yet, come back in a bit!")
+        CryticPrint().print_error(
+            "The --dry-run command isn't implemented yet, come back in a bit!"
+        )
 
     check_config_and_set_default_values(
         config,
@@ -103,8 +105,8 @@ def modify_command(args: Namespace) -> None:
 
     if config["fuzzer"] not in {"echidna", "medusa"}:
         handle_exit(
-                f"\n* The requested fuzzer {config['fuzzer']} is not supported. Supported fuzzers: echidna, medusa."
-            )
+            f"\n* The requested fuzzer {config['fuzzer']} is not supported. Supported fuzzers: echidna, medusa."
+        )
 
     corpus_modifier = CorpusModifier(config, slither)
     corpus_modifier.modify_corpus()

--- a/fuzz_utils/parsing/commands/modify_corpus.py
+++ b/fuzz_utils/parsing/commands/modify_corpus.py
@@ -1,0 +1,86 @@
+"""Defines the flags and logic associated with the `modify-corpus` command"""
+from argparse import Namespace, ArgumentParser
+from slither import Slither
+from fuzz_utils.utils.crytic_print import CryticPrint
+from fuzz_utils.modify_corpus.CorpusModifier import CorpusModifier
+from fuzz_utils.utils.error_handler import handle_exit
+from fuzz_utils.parsing.parser_util import check_config_and_set_default_values, open_config
+
+COMMAND: str = "modify-corpus"
+
+
+def modify_flags(parser: ArgumentParser) -> None:
+    """The unit test generation parser flags"""
+    parser.add_argument(
+        "compilation_path", help="Path to the Echidna/Medusa test harness or Foundry directory."
+    )
+    parser.add_argument(
+        "-cd", "--corpus-dir", dest="corpus_dir", help="Path to the corpus directory"
+    )
+    parser.add_argument(
+        "-f",
+        "--fuzzer",
+        dest="selected_fuzzer",
+        help="Define the fuzzer used. Valid inputs: 'echidna', 'medusa'",
+    )
+    parser.add_argument(
+        "--fuzzer-config",
+        dest="fuzzer_config",
+        help="Define the location of the fuzzer config file.",
+    )
+    # TODO add specific commands for modifying the corpus
+
+
+# pylint: disable=too-many-branches
+def modify_command(args: Namespace) -> None:
+    """The execution logic of the `modify-corpus` command"""
+    config: dict = {}
+
+    # If the config file is defined, read it
+    if args.config:
+        config = open_config(args.config, COMMAND)
+    # Override the config with the CLI values
+    if args.compilation_path:
+        config["compilationPath"] = args.compilation_path
+    if args.selected_fuzzer:
+        config["fuzzer"] = args.selected_fuzzer.lower()
+    if args.corpus_dir:
+        config["corpusDir"] = args.corpus_dir
+    if args.fuzzer_config:
+        config["fuzzerConfig"] = args.fuzzer_config
+
+    check_config_and_set_default_values(
+        config,
+        ["compilationPath", "fuzzer", "corpusDir"],
+        [".", "echidna", "corpus"],
+    )
+
+    CryticPrint().print_information("Running Slither...")
+    slither = Slither(args.compilation_path)
+
+    derive_config(slither, config)
+
+    if config["fuzzer"] not in {"echidna", "medusa"}:
+        handle_exit(
+                f"\n* The requested fuzzer {config['fuzzer']} is not supported. Supported fuzzers: echidna, medusa."
+            )
+
+    corpus_modifier = CorpusModifier(config["fuzzerConfig"], config["corpusDir"], slither, config["fuzzer"])
+    corpus_modifier.modify_corpus()
+
+    CryticPrint().print_success("Done!")
+
+
+def derive_config(slither: Slither, config: dict) -> None:
+    """Derive values for the target contract and inheritance path"""
+    # Derive target if it is not defined but the compilationPath only contains one contract
+    if "targetContract" not in config or len(config["targetContract"]) == 0:
+        if len(slither.contracts_derived) == 1:
+            config["targetContract"] = slither.contracts_derived[0].name
+            CryticPrint().print_information(
+                f"Target contract not specified. Using derived target: {config['targetContract']}."
+            )
+        else:
+            handle_exit(
+                "Target contract cannot be determined. Please specify the target with `-c targetName`"
+            )

--- a/fuzz_utils/parsing/commands/modify_corpus.py
+++ b/fuzz_utils/parsing/commands/modify_corpus.py
@@ -17,6 +17,7 @@ def modify_flags(parser: ArgumentParser) -> None:
     parser.add_argument(
         "-cd", "--corpus-dir", dest="corpus_dir", help="Path to the corpus directory"
     )
+    parser.add_argument("-c", "--contract", dest="target_contract", help="Define the contract name")
     parser.add_argument(
         "-f",
         "--fuzzer",
@@ -28,6 +29,33 @@ def modify_flags(parser: ArgumentParser) -> None:
         dest="fuzzer_config",
         help="Define the location of the fuzzer config file.",
     )
+    parser.add_argument(
+        "--mode",
+        dest="filter_mode",
+        help="Define how the corpus will me modified. Available options are: `delete_sequence` and `delete_calls`",
+    )
+    parser.add_argument(
+        "--modify-senders",
+        dest="modify_senders",
+        nargs="+",
+        help="Define sender remappings in the format `0xoldSender=0xnewSender,0xold2=0xnew2,...`",
+    )
+    parser.add_argument(
+        "-ff",
+        "--filter-functions",
+        dest="filter_functions",
+        help="Remove functions that no longer exist from the corpus.",
+        default=False,
+        action="store_true",
+    )
+    parser.add_argument(
+        "-dr",
+        "--dry-run",
+        dest="dry_run",
+        help="Print out any corpus calls that would be modified.",
+        default=False,
+        action="store_true",
+    )
     # TODO add specific commands for modifying the corpus
 
 
@@ -36,23 +64,36 @@ def modify_command(args: Namespace) -> None:
     """The execution logic of the `modify-corpus` command"""
     config: dict = {}
 
-    # If the config file is defined, read it
-    if args.config:
-        config = open_config(args.config, COMMAND)
     # Override the config with the CLI values
     if args.compilation_path:
         config["compilationPath"] = args.compilation_path
+    if args.target_contract:
+        config["targetContract"] = args.target_contract
     if args.selected_fuzzer:
         config["fuzzer"] = args.selected_fuzzer.lower()
     if args.corpus_dir:
         config["corpusDir"] = args.corpus_dir
     if args.fuzzer_config:
-        config["fuzzerConfig"] = args.fuzzer_config
+        config["fuzzerConfigPath"] = args.fuzzer_config
+    if args.filter_mode:
+        config["mode"] = args.filter_mode
+    if args.modify_senders:
+        config["modifySenders"] = {}
+        # Process list
+        for item in args.modify_senders:
+            assert("=" in item)
+            senders = item.split("=")
+            config["modifySenders"][senders[0]] = senders[1]
+    if args.filter_functions:
+        config["filterFunctions"] = args.filter_functions
+    if args.dry_run:
+        config["dryRun"] = args.dry_run
+        CryticPrint().print_error("The --dry-run command isn't implemented yet, come back in a bit!")
 
     check_config_and_set_default_values(
         config,
-        ["compilationPath", "fuzzer", "corpusDir"],
-        [".", "echidna", "corpus"],
+        ["compilationPath", "fuzzer", "corpusDir", "mode"],
+        [".", "echidna", "corpus", "filter_calls"],
     )
 
     CryticPrint().print_information("Running Slither...")
@@ -65,7 +106,7 @@ def modify_command(args: Namespace) -> None:
                 f"\n* The requested fuzzer {config['fuzzer']} is not supported. Supported fuzzers: echidna, medusa."
             )
 
-    corpus_modifier = CorpusModifier(config["fuzzerConfig"], config["corpusDir"], slither, config["fuzzer"])
+    corpus_modifier = CorpusModifier(config, slither)
     corpus_modifier.modify_corpus()
 
     CryticPrint().print_success("Done!")

--- a/fuzz_utils/parsing/commands/restore.py
+++ b/fuzz_utils/parsing/commands/restore.py
@@ -25,8 +25,9 @@ def restore_flags(parser: ArgumentParser) -> None:
 # pylint: disable=too-many-branches
 def restore_command(args: Namespace) -> None:
     """The execution logic of the `restore` command"""
+    config: dict = {}
 
-    corpus_modifier = CorpusModifier(None, None, None, None)
+    corpus_modifier = CorpusModifier(config, None)
     # Override the config with the CLI values
     if args.list_history:
         corpus_modifier.list_historic_corpora()

--- a/fuzz_utils/parsing/commands/restore.py
+++ b/fuzz_utils/parsing/commands/restore.py
@@ -10,7 +10,10 @@ COMMAND: str = "modify-corpus"
 def restore_flags(parser: ArgumentParser) -> None:
     """The unit test generation parser flags"""
     parser.add_argument(
-        "-ch", "--hash", dest="corpus_hash", help="Hash of the historic corpus that will be restored."
+        "-ch",
+        "--hash",
+        dest="corpus_hash",
+        help="Hash of the historic corpus that will be restored.",
     )
     parser.add_argument(
         "-lh",
@@ -33,6 +36,7 @@ def restore_command(args: Namespace) -> None:
         corpus_modifier.list_historic_corpora()
     else:
         if args.corpus_hash:
+            CryticPrint().print_information(f"Restoring corpus with hash: {args.corpus_hash}")
             corpus_modifier.restore_corpus_from_history(args.corpus_hash)
         else:
             handle_exit("No hash was provided!")

--- a/fuzz_utils/parsing/commands/restore.py
+++ b/fuzz_utils/parsing/commands/restore.py
@@ -1,0 +1,37 @@
+"""Defines the flags and logic associated with the `modify-corpus` command"""
+from argparse import Namespace, ArgumentParser
+from fuzz_utils.utils.crytic_print import CryticPrint
+from fuzz_utils.modify_corpus.CorpusModifier import CorpusModifier
+from fuzz_utils.utils.error_handler import handle_exit
+
+COMMAND: str = "modify-corpus"
+
+
+def restore_flags(parser: ArgumentParser) -> None:
+    """The unit test generation parser flags"""
+    parser.add_argument(
+        "-ch", "--hash", dest="corpus_hash", help="Hash of the historic corpus that will be restored."
+    )
+    parser.add_argument(
+        "-lh",
+        "--list-history",
+        dest="list_history",
+        help="List the corpora that are saved in history.",
+        default=False,
+        action="store_true",
+    )
+
+
+# pylint: disable=too-many-branches
+def restore_command(args: Namespace) -> None:
+    """The execution logic of the `restore` command"""
+
+    corpus_modifier = CorpusModifier(None, None, None, None)
+    # Override the config with the CLI values
+    if args.list_history:
+        corpus_modifier.list_historic_corpora()
+    else:
+        if args.corpus_hash:
+            corpus_modifier.restore_corpus_from_history(args.corpus_hash)
+        else:
+            handle_exit("No hash was provided!")

--- a/fuzz_utils/parsing/commands/snapshot.py
+++ b/fuzz_utils/parsing/commands/snapshot.py
@@ -1,0 +1,43 @@
+"""Defines the flags and logic associated with the `modify-corpus` command"""
+from argparse import Namespace, ArgumentParser
+from fuzz_utils.utils.crytic_print import CryticPrint
+from fuzz_utils.modify_corpus.CorpusModifier import CorpusModifier
+from fuzz_utils.utils.error_handler import handle_exit
+from fuzz_utils.parsing.parser_util import check_config_and_set_default_values
+
+COMMAND: str = "modify-corpus"
+
+
+def snapshot_flags(parser: ArgumentParser) -> None:
+    """The unit test generation parser flags"""
+    parser.add_argument(
+        "-cd", "--corpus-dir", dest="corpus_dir", help="Path to the corpus directory"
+    )
+    parser.add_argument(
+        "-f",
+        "--fuzzer",
+        dest="selected_fuzzer",
+        help="Define the fuzzer used. Valid inputs: 'echidna', 'medusa'",
+    )
+
+
+# pylint: disable=too-many-branches
+def snapshot_command(args: Namespace) -> None:
+    """The execution logic of the `snapshot` command"""
+    config: dict = {}
+
+    if args.corpus_dir:
+        config["corpusDir"] = args.corpus_dir
+    if args.selected_fuzzer:
+        config["fuzzer"] = args.selected_fuzzer.lower()
+        if config["fuzzer"] not in {"echidna", "medusa"}:
+            handle_exit(f"The provided fuzzer {config['fuzzer']} is not supported.")
+
+    check_config_and_set_default_values(
+        config,
+        ["fuzzer", "corpusDir"],
+        ["echidna", "corpus"],
+    )
+
+    corpus_modifier = CorpusModifier(None, config["corpusDir"], None, config["fuzzer"])
+    corpus_modifier.save_corpus_to_history()

--- a/fuzz_utils/parsing/commands/snapshot.py
+++ b/fuzz_utils/parsing/commands/snapshot.py
@@ -39,5 +39,5 @@ def snapshot_command(args: Namespace) -> None:
         ["echidna", "corpus"],
     )
 
-    corpus_modifier = CorpusModifier(None, config["corpusDir"], None, config["fuzzer"])
+    corpus_modifier = CorpusModifier(config, None)
     corpus_modifier.save_corpus_to_history()

--- a/fuzz_utils/parsing/commands/snapshot.py
+++ b/fuzz_utils/parsing/commands/snapshot.py
@@ -40,4 +40,5 @@ def snapshot_command(args: Namespace) -> None:
     )
 
     corpus_modifier = CorpusModifier(config, None)
+    CryticPrint().print_information(f"Saving corpus {args.corpus_dir} to history...")
     corpus_modifier.save_corpus_to_history()

--- a/fuzz_utils/parsing/parser.py
+++ b/fuzz_utils/parsing/parser.py
@@ -4,6 +4,9 @@ from argparse import Namespace, _SubParsersAction
 from fuzz_utils.parsing.commands.generate import generate_command, generate_flags
 from fuzz_utils.parsing.commands.template import template_command, template_flags
 from fuzz_utils.parsing.commands.init import init_command, init_flags
+from fuzz_utils.parsing.commands.restore import restore_command, restore_flags
+from fuzz_utils.parsing.commands.snapshot import snapshot_command, snapshot_flags
+from fuzz_utils.parsing.commands.modify_corpus import modify_command, modify_flags
 
 parsers: dict[str, dict[str, Any]] = {
     "init": {
@@ -22,6 +25,24 @@ parsers: dict[str, dict[str, Any]] = {
         "command": generate_command,
         "help": "Generate unit tests from fuzzer corpora sequences.",
         "flags": generate_flags,
+        "subparser": None,
+    },
+    "modify-corpus": {
+        "command": modify_command,
+        "help": "Modifies the provided corpus.",
+        "flags": modify_flags,
+        "subparser": None,
+    },
+    "snapshot": {
+        "command": snapshot_command,
+        "help": "Save the provided corpus directory.",
+        "flags": snapshot_flags,
+        "subparser": None,
+    },
+    "restore": {
+        "command": restore_command,
+        "help": "Restore a corpus directory from a historic hash.",
+        "flags": restore_flags,
         "subparser": None,
     },
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ dependencies = [
     "jinja2>=3.1.0",
     "eth_abi>=5.0.1",
     "eth_utils>=4.0.0",
-    "eth_typing>=4.0.0"
+    "eth_typing>=4.0.0",
+    "pyyaml>=6.0.1"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR adds the ability to modify an Echidna or Medusa corpus based on certain conditions, save a corpus into a corpus "history" file, and restore a previously saved corpus.

It includes the following changes:

- New CLI commands:
    -  `modify-corpus`: Modifies an existing corpus based on the fuzzer configuration or data provided via flags. The available conditions are:
        - `--fuzzer-config`: Fetches the maximum time delay, maximum block delay, or blacklisted functions defined in the fuzzer configuration file. Calls or call sequences that use a larger time/block delay than defined, or use a blacklisted function, are discarded.
        - `--modify-senders` LIST: Takes in a list of the format `0xoldAddress=0xnewAddress,...`, and replaces the caller for all calls that use the `oldAddress` with `newAddress`
        - `--filter-functions`: Removes calls or call sequences that call functions that no longer exist. Currently supports only one target contract.
        - `--mode` `delete_sequence` | `delete_calls`: Defines how filtering is done, `delete_sequence` deletes the entire call sequence file if any call within it is invalid per the included rules. `delete_calls` only deletes the invalid call.
    - `snapshot`: Saves the provided corpus directory into a `history.json` file so it can be easily retrieved. E.g., in case we want to rollback the changes we made to the corpus. Available flags: `--corpus-dir`, `--fuzzer`
    - `restore`: Restores a corpus from the `history.json` file, it will override the directory where it was previously saved. Available flags: `--list-history` (lists all saved corpora with their hashes), `--hash` STR (takes in a hash of the corpus we want to restore)
- New parsers and a new class `CorpusModifier` were added to support the above features.
- `pyYAML` was added as a dependancy so we can process echidna `.yaml` config files

Before merging this PR further work should be done to:

- [ ] Sanity check modification of Medusa corpora (only tested Echidna so far)
- [ ] Create unit tests for each of the features
- [ ] Resolve ignored mypy errors
- [ ] Add support for multiple contracts when using `--filter-functions`
- [ ] Add error handling to file system manipulation
- [ ] Fix bug where corpus directories are not properly saved when using `delete_sequences`