### PR TITLE
fix cancun compilation error for pytest actions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,7 +120,7 @@ def setup_foundry_temp_dir(tmp_path_factory: Any) -> None:
 
     # Create foundry config
     foundry_config = os.path.join(temp_dir, "foundry.toml")
-    out_str: str = "[profile.default]\nsolc-version = \"0.8.19\"\nevm_version = \"shanghai\""
+    out_str: str = '[profile.default]\nsolc-version = "0.8.19"\nevm_version = "shanghai"'
     with open(foundry_config, "w", encoding="utf-8") as outfile:
         outfile.write(out_str)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,6 +117,13 @@ def setup_foundry_temp_dir(tmp_path_factory: Any) -> None:
     subprocess.run(
         ["forge", "install", "transmissions11/solmate", "--no-git"], check=True, cwd=temp_dir
     )
+
+    # Create foundry config
+    foundry_config = os.path.join(temp_dir, "foundry.toml")
+    out_str: str = "[profile.default]\nsolc-version = \"0.8.19\"\nevm_version = \"shanghai\""
+    with open(foundry_config, "w", encoding="utf-8") as outfile:
+        outfile.write(out_str)
+
     # Create remappings file
     create_remappings_file(temp_dir, None)
 


### PR DESCRIPTION
Pytest actions failed due to an update to foundry defaulting to the cancun evm version. Fixed it by explicitly defining the version as shanghai